### PR TITLE
Added dumping of private key and certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Azure Key Vault agent container does the following -
 * It runs before any other container as an init-container
 * It connects to Azure Key Vault using the cluster's service principle
 * It then grabs the desired secrets and/or certificates from Azure Key Vault and stores them in a shared volume (memory only - tmpfs)
-* If a secret refers to a key that is backing a certificate, both private key and certificates are exported as pem
+* If a secret refers to a key that is backing a certificate, both private key and certificate are exported as pem
 * It terminates and let other containers run
 * Finally, other containers have access to the secrets using a shared volume
 
@@ -52,7 +52,7 @@ and now just view the secrets with
 ```
 cat /secrets/secrets/<secret_name>
 cat /secrets/certs/<certificate_name>
-cat /secrets/keys/<secret_name>
+cat /secrets/keys/<key_name>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Azure Key Vault agent container does the following -
 * It runs before any other container as an init-container
 * It connects to Azure Key Vault using the cluster's service principle
 * It then grabs the desired secrets and/or certificates from Azure Key Vault and stores them in a shared volume (memory only - tmpfs)
+* If a secret refers to a key that is backing a certificate, both private key and certificates are exported as pem
 * It terminates and let other containers run
 * Finally, other containers have access to the secrets using a shared volume
 
@@ -31,9 +32,9 @@ docker push <image_tag>
 ```
 
 * Edit `examples/acs-keyvault-deployment.yaml` file and change - 
-  * `<IMAGE_PATH>` - the image you just built earlier
-  * `<VAULT_URL>` - should be something like: `https://<NAME>.vault.azure.net`
-  * `<SECRET_KEYS>` - a list of keys and their versions (optional), represented as a string, formatted like: `<secret_name>:<secret_version>;<another_secret>` 
+  * `<IMAGE_PATH>` - the image you just built earlier.
+  * `<VAULT_URL>` - should be something like: `https://<NAME>.vault.azure.net`.
+  * `<SECRET_KEYS>` - a list of keys and their versions (optional), represented as a string, formatted like: `<secret_name>:<secret_version>;<another_secret>`. If a secret is backing a certificate, private key and certificate will be downloaded in PEM format at `keys/` and `certs/` respectively. 
   for example
   `mysecret:9d90276b377b4d9ea10763c153a2f015;anotherone;`
   * `<CERTS_KEYS>` - a list of certificates and their versions (optional), represented as a string, formatted like: `<cert_name>:<cert_version>;<another_cert>`. Certificates will be downloaded in PEM format. 
@@ -51,6 +52,7 @@ and now just view the secrets with
 ```
 cat /secrets/secrets/<secret_name>
 cat /secrets/certs/<certificate_name>
+cat /secrets/keys/<secret_name>
 ```
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -83,11 +83,14 @@ class KeyVaultAgent(object):
         output_folder = os.getenv('SECRETS_FOLDER')
 	secrets_output_folder = os.path.join(output_folder, "secrets")
 	certs_output_folder = os.path.join(output_folder, "certs")
+        keys_output_folder = os.path.join(output_folder, "keys")
 
         if not os.path.exists(secrets_output_folder) :
               os.makedirs(secrets_output_folder)
         if not os.path.exists(certs_output_folder) :
               os.makedirs(certs_output_folder)
+        if not os.path.exists(keys_output_folder) :
+              os.makedirs(keys_output_folder)
 
         client = self._get_client()
         _logger.info('Using vault: %s', vault_base_url)
@@ -98,6 +101,9 @@ class KeyVaultAgent(object):
                    _logger.info('Retrieving secret name:%s with version: %s', key_name, key_version)
            	   secret = client.get_secret(vault_base_url, key_name, key_version)
                    output_path = os.path.join(secrets_output_folder, key_name)
+                   if secret.kid is not None:
+                         _logger.info('Secret is backing certificate. Dumping private key and certificate.')
+                         self.dump_pfx(secret.value, key_name, keys_output_folder, certs_output_folder)
                    _logger.info('Dumping secret value to: %s', output_path)
                    with open(output_path, 'w') as secret_file:
                          secret_file.write(secret.value)
@@ -110,13 +116,24 @@ class KeyVaultAgent(object):
                   output_path = os.path.join(certs_output_folder, key_name)
                   _logger.info('Dumping cert value to: %s', output_path)
                   with open(output_path, 'w') as cert_file:
-                      cert_file.write(self.to_pem(cert.cer))
+                      cert_file.write(self.cert_to_pem(cert.cer))
 
-    def to_pem(self, cert):
+    def dump_pfx(self, pfx, name, keys_output_folder, certs_output_folder):
+              import base64
+              from OpenSSL import crypto
+              p12 = crypto.load_pkcs12(base64.decodestring(pfx))
+              pk = crypto.dump_privatekey(crypto.FILETYPE_PEM, p12.get_privatekey())
+              cert = crypto.dump_certificate(crypto.FILETYPE_PEM, p12.get_certificate())
+              with open(os.path.join(keys_output_folder, name), 'w') as key_file:
+                    key_file.write(pk)
+              with open(os.path.join(certs_output_folder, name), 'w') as cert_file:
+                    cert_file.write(cert)
+              
+    def cert_to_pem(self, cert):
               import base64
               encoded = base64.encodestring(cert) 
               if isinstance(encoded, bytes):
-                      encoded = encoded.decode("utf-8")
+                    encoded = encoded.decode("utf-8")
               encoded = '-----BEGIN CERTIFICATE-----\n' + encoded + '-----END CERTIFICATE-----\n'
 
               return encoded

--- a/app/main.py
+++ b/app/main.py
@@ -81,16 +81,13 @@ class KeyVaultAgent(object):
         secrets_keys = os.getenv('SECRETS_KEYS')
         certs_keys = os.getenv('CERTS_KEYS')
         output_folder = os.getenv('SECRETS_FOLDER')
-	secrets_output_folder = os.path.join(output_folder, "secrets")
-	certs_output_folder = os.path.join(output_folder, "certs")
-        keys_output_folder = os.path.join(output_folder, "keys")
+	self.secrets_output_folder = os.path.join(output_folder, "secrets")
+	self.certs_output_folder = os.path.join(output_folder, "certs")
+        self.keys_output_folder = os.path.join(output_folder, "keys")
 
-        if not os.path.exists(secrets_output_folder) :
-              os.makedirs(secrets_output_folder)
-        if not os.path.exists(certs_output_folder) :
-              os.makedirs(certs_output_folder)
-        if not os.path.exists(keys_output_folder) :
-              os.makedirs(keys_output_folder)
+        for folder in (self.secrets_output_folder, self.certs_output_folder, self.keys_output_folder):
+              if not os.path.exists(folder) :
+                    os.makedirs(folder)
 
         client = self._get_client()
         _logger.info('Using vault: %s', vault_base_url)
@@ -100,10 +97,10 @@ class KeyVaultAgent(object):
                    key_name, _, key_version = key_info.partition(':')
                    _logger.info('Retrieving secret name:%s with version: %s', key_name, key_version)
            	   secret = client.get_secret(vault_base_url, key_name, key_version)
-                   output_path = os.path.join(secrets_output_folder, key_name)
+                   output_path = os.path.join(self.secrets_output_folder, key_name)
                    if secret.kid is not None:
                          _logger.info('Secret is backing certificate. Dumping private key and certificate.')
-                         self.dump_pfx(secret.value, key_name, keys_output_folder, certs_output_folder)
+                         self.dump_pfx(secret.value, key_name)
                    _logger.info('Dumping secret value to: %s', output_path)
                    with open(output_path, 'w') as secret_file:
                          secret_file.write(secret.value)
@@ -113,20 +110,20 @@ class KeyVaultAgent(object):
                   key_name, _, key_version = key_info.partition(':')
                   _logger.info('Retrieving cert name:%s with version: %s', key_name, key_version)
                   cert = client.get_certificate(vault_base_url, key_name, key_version)
-                  output_path = os.path.join(certs_output_folder, key_name)
+                  output_path = os.path.join(self.certs_output_folder, key_name)
                   _logger.info('Dumping cert value to: %s', output_path)
                   with open(output_path, 'w') as cert_file:
                       cert_file.write(self.cert_to_pem(cert.cer))
 
-    def dump_pfx(self, pfx, name, keys_output_folder, certs_output_folder):
+    def dump_pfx(self, pfx, name):
               import base64
               from OpenSSL import crypto
               p12 = crypto.load_pkcs12(base64.decodestring(pfx))
               pk = crypto.dump_privatekey(crypto.FILETYPE_PEM, p12.get_privatekey())
               cert = crypto.dump_certificate(crypto.FILETYPE_PEM, p12.get_certificate())
-              with open(os.path.join(keys_output_folder, name), 'w') as key_file:
+              with open(os.path.join(self.keys_output_folder, name), 'w') as key_file:
                     key_file.write(pk)
-              with open(os.path.join(certs_output_folder, name), 'w') as cert_file:
+              with open(os.path.join(self.certs_output_folder, name), 'w') as cert_file:
                     cert_file.write(cert)
               
     def cert_to_pem(self, cert):

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,4 @@
 azure-keyvault==0.3.5
 msrestazure==0.4.11
 adal==0.4.6
-pyopenssl
+pyopenssl==17.5.0

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
 azure-keyvault==0.3.5
 msrestazure==0.4.11
 adal==0.4.6
+pyopenssl


### PR DESCRIPTION
In cases when `secret ` refers to a key backing a certificate, download both private key in `keys/` and certificate in `certs/` in PEM format.

For example, if `myssl` secret is requested, the following will be downloaded:
`keys/myssl` containing private key.
`certs/myssl` containing the certificate.