### PR TITLE
Adding ability to create secrets of custom type and custom key value pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ docker push <image_tag>
   * `<SECRET_KEYS>` - a list of keys and their versions (optional), represented as a string, formatted like: `<secret_name>:<secret_version>;<another_secret>`. If a secret is backing a certificate, private key and certificate will be downloaded in PEM format at `keys/` and `certs/` respectively. 
   for example
   `mysecret:9d90276b377b4d9ea10763c153a2f015;anotherone;`
+  * if you like to create secrets of a perticular kind (for example for use in DaemonSets), create an environment variable with the name of the secret that you are creating in uppercase appended by `_SECRET_TYPE`. For example, if the key name in keyvault is `mysecret` then to create a secret of type `MyCustomType`, set the environment variable `MYSECRET_SECRET_TYPE` to `MyCustomType`. This will be applicable only for that secret name.
+  * if you'd like to install secrets with key value other than the default `secret`, then you can do that by creating an environment variable with name `_SECRETS_DATA_KEY`. For example if you have a secret called `DBConnectionString` and if you would like to install a secret with key as `connectionString` and value to be the base64 encoded connection string, then create a environment variable `DBCONNECTIONSTRING_SECRETS_DATA_KEY` and set its value to `connectionString`
 * View secrets
 ```
 kubectl get secrets

--- a/app/main.py
+++ b/app/main.py
@@ -126,8 +126,10 @@ class KeyVaultAgent(object):
         encoded_secret = base64.b64encode(bytes(value))
 
         secret.metadata = client.V1ObjectMeta(name=key)
-        secret.type = os.getenv('SECRETS_TYPE', 'Opaque')
-        secret_data_key = os.getenv('SECRETS_DATA_KEY', 'secret')
+        secretTypeEnvKey = key.upper() + "_SECRET_TYPE"
+        secret.type = os.getenv(secretTypeEnvKey, 'Opaque')
+        secretDataKey = key.upper() + "_SECRETS_DATA_KEY"
+        secret_data_key = os.getenv(secretDataKey, 'secret')
         secret.data = { secret_data_key : encoded_secret }
 
         secrets_list = self._get_kubernetes_secrets_list()

--- a/app/main.py
+++ b/app/main.py
@@ -126,8 +126,9 @@ class KeyVaultAgent(object):
         encoded_secret = base64.b64encode(bytes(value))
 
         secret.metadata = client.V1ObjectMeta(name=key)
-        secret.type = "Opaque"
-        secret.data = { "secret" : encoded_secret }
+        secret.type = os.getenv('SECRETS_TYPE', 'Opaque')
+        secret_data_key = os.getenv('SECRETS_DATA_KEY', 'secret')
+        secret.data = { secret_data_key : encoded_secret }
 
         secrets_list = self._get_kubernetes_secrets_list()
 


### PR DESCRIPTION
When installing certain kinds of kubernetes resources, it is desirable to create its associated secrets of a particular custom type, like in a case when installing a DaemonSet. This PR adds that ability to acs-keyvault-agent.

Also it is sometimes desirable to have custom key values for the secrets, like having key as username / connectionstring etc. Earlier, the default key was 'secret'. This PR adds the ability to have custom key type for a key. 