### PR TITLE
Download CA certs for K8s secrets flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ docker push <image_tag>
   * `<SECRET_KEYS>` - a list of keys and their versions (optional), represented as a string, formatted like: `<secret_name>:<secret_version>;<another_secret>`. If a secret is backing a certificate, private key and certificate will be downloaded in PEM format at `keys/` and `certs/` respectively. 
   for example
   `mysecret:9d90276b377b4d9ea10763c153a2f015;anotherone;`
+  * `<DOWNLOAD_CA_CERTIFICATES>` - By default, CA certificates are downloaded as well. Setting the environment variable to `true` or `false` controls this behavior.
   * `<CERTS_KEYS>` - a list of certificates and their versions (optional), represented as a string, formatted like: `<cert_name>:<cert_version>;<another_cert>`. Certificates will be downloaded in PEM format. 
   
 


### PR DESCRIPTION
For K8s secrets mode, the CA certificates were not downloaded. This fixes this issue and correct the documentation. 