### PR TITLE
Upgrade ADAL to its latest 1.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 azure-keyvault==1.0.0
 msrestazure==0.4.34
-adal==1.0.2
+adal==1.2.4
 pyopenssl==18.0.0
 kubernetes==6.0.0


### PR DESCRIPTION
Otherwise it won't work in some of the Azure Clouds.
The new ADAL is a drop-in replacement of the old one. (I'm the maintainer of ADAL.)
This change has been tested by my colleague Abdulaziz Mohammed. (Thanks Abdu!)