### PR TITLE
Add support for user-assigned MSI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 An Azure Key Vault agent container that grabs secrets from Azure Key Vault securely and passes them to other containers in its pod, either by shared volume or Kubernetes secrets objects
 
 # How does it work?
-The Azure Key Vault agent container does the following - 
+The Azure Key Vault agent container does the following -
 * It runs before any other container as an init-container
 * It connects to Azure Key Vault using the cluster's service principle
 * It then grabs the desired secrets and/or certificates from Azure Key Vault and stores them in a shared volume (memory only - tmpfs)
 * If a secret refers to a key that is backing a certificate, both private key and certificate are exported as pem
 * It terminates and let other containers run
 * Finally, other containers have access to the secrets using a shared volume
-When creating Kubernetes secrets objects - 
+When creating Kubernetes secrets objects -
 * It connects to Azure Key Vault using the cluster's service principle
 * It then grabs the desired secrets from Azure Key Vault and stores them as Kubernetes secrets objects. These objects are stored unencrypted by default in etcd, and are readable by other pods in the namespace.
 
@@ -24,7 +24,7 @@ When creating Kubernetes secrets objects -
 
 # How to use it
 * Config your Azure Key Vault to give your cluster's service principle a "get" permission so it can grab secrets
-* Clone the project to your desired folder 
+* Clone the project to your desired folder
 * Build the agent image using docker
 ```
 cd <project_root>
@@ -35,15 +35,15 @@ docker build . -t <image_tag>
 docker push <image_tag>
 ```
 
-* Edit `examples/acs-keyvault-deployment.yaml` file and change - 
+* Edit `examples/acs-keyvault-deployment.yaml` file and change -
   * `<IMAGE_PATH>` - the image you just built earlier.
   * `<VAULT_URL>` - should be something like: `https://<NAME>.vault.azure.net`.
-  * `<SECRET_KEYS>` - a list of keys and their versions (optional), represented as a string, formatted like: `<secret_name>:<secret_version>;<another_secret>`. If a secret is backing a certificate, private key and certificate will be downloaded in PEM format at `keys/` and `certs/` respectively. 
+  * `<SECRET_KEYS>` - a list of keys and their versions (optional), represented as a string, formatted like: `<secret_name>:<secret_version>;<another_secret>`. If a secret is backing a certificate, private key and certificate will be downloaded in PEM format at `keys/` and `certs/` respectively.
   for example
   `mysecret:9d90276b377b4d9ea10763c153a2f015;anotherone;`
   * `<DOWNLOAD_CA_CERTIFICATES>` - By default, CA certificates are downloaded as well. Setting the environment variable to `true` or `false` controls this behavior.
-  * `<CERTS_KEYS>` - a list of certificates and their versions (optional), represented as a string, formatted like: `<cert_name>:<cert_version>;<another_cert>`. Certificates will be downloaded in PEM format. 
-  
+  * `<CERTS_KEYS>` - a list of certificates and their versions (optional), represented as a string, formatted like: `<cert_name>:<cert_version>;<another_cert>`. Certificates will be downloaded in PEM format.
+
 
 * Create the deployment using
 ```
@@ -53,7 +53,7 @@ kubectl create -f ./examples/acs-keyvault-deployment.yaml
 ```
 kubectl exec -ti test-keyvault-7d94566cdb-7wmx9 -c test-app /bin/sh
 ```
-and now just view the secrets with 
+and now just view the secrets with
 ```
 cat /secrets/secrets/<secret_name>
 cat /secrets/certs/<certificate_name>
@@ -63,7 +63,7 @@ cat /secrets/keys/<key_name>
 # How to use it - Kubernetes Secrets
 * Config your Azure Key Vault to give your cluster's service principle a "get" permission so it can grab secrets
 * Ensure that your secret names follow Kubernetes standard - must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
-* Clone the project to your desired folder 
+* Clone the project to your desired folder
 * Build the agent image using docker
 ```
 cd <project_root>
@@ -79,7 +79,7 @@ docker push <image_tag>
   * `<VAULT_URL>` - should be something like: `https://<NAME>.vault.azure.net`.
   * `<CREATE_KUBERNETES_SECRETS>` - "true" or "false", whether or not you'd like kubernetes secrets objects created.
   * `<SECRETS_NAMESPACE>` - a string value if you want to use a namespace other than default.
-  * `<SECRETS_KEYS>` - a list of keys and their versions (optional), represented as a string, formatted like: `<secret_name>:<secret_version>;<another_secret>`. If a secret is backing a certificate, private key and certificate will be downloaded in PEM format at `keys/` and `certs/` respectively. 
+  * `<SECRETS_KEYS>` - a list of keys and their versions (optional), represented as a string, formatted like: `<secret_name>:<secret_version>;<another_secret>`. If a secret is backing a certificate, private key and certificate will be downloaded in PEM format at `keys/` and `certs/` respectively.
   for example
   `mysecret:9d90276b377b4d9ea10763c153a2f015;anotherone;`
   * `<DOWNLOAD_CA_CERTIFICATES>` - By default, CA certificates are downloaded as well. Setting the environment variable to `true` or `false` controls this behavior.
@@ -88,6 +88,9 @@ docker push <image_tag>
   * If you like to create secrets of a particular kind (for example for use in DaemonSets), create an environment variable with the name of the secret that you are creating in uppercase appended by `_SECRET_TYPE`. For example, if the key name in keyvault is `mysecret` then to create a secret of type `MyCustomType`, set the environment variable `MYSECRET_SECRET_TYPE` to `MyCustomType`. This will be applicable only for that secret name, and overrides any value set for '<SECRETS_TYPE>' key. Default is 'Opaque'.
   * If you'd like to install secrets with key value other than the default `secret`, then you can do that by creating an environment variable with name `_SECRETS_DATA_KEY`. For example if you have a secret called `DBConnectionString` and if you would like to install a secret with key as `connectionString` and value to be the base64 encoded connection string, then create a environment variable `DBCONNECTIONSTRING_SECRETS_DATA_KEY` and set its value to `connectionString`
   * `<AUTO_DETECT_AAD_TENANT>` - By default, `tenantId` from cloud config is used for authentication. Setting the environment variable to `true` will automatically detect the AAD `tenantId` for your keyvault. This is useful during AAD tenant migration of subscription.
+  * `<MSI_CLIENT_ID>` - This will use a specific client_id when authenticating with MSI. This is useful if you are using user-assigned identities.
+  * `<MSI_OBJECT_ID>` - This will use a specific object_id when authenticating with MSI. This is useful if you are using user-assigned identities.
+  * `<MSI_CLIENT_ID>` - This will use a specific MSI resource ID when authenticating with MSI. This is useful if you are using user-assigned identities.
 * View secrets
 ```
 kubectl get secrets

--- a/app/main.py
+++ b/app/main.py
@@ -78,7 +78,20 @@ class KeyVaultAgent(object):
     def _get_client(self):
         if os.getenv("USE_MSI", "false").lower() == "true":
             _logger.info('Using MSI')
-            credentials = MSIAuthentication(resource=VAULT_RESOURCE_NAME)
+            if "MSI_CLIENT_ID" in os.environ:
+                msi_client_id = os.environ["MSI_CLIENT_ID"]
+                _logger.info('Using client_id: %s', msi_client_id)
+                credentials = MSIAuthentication(resource=VAULT_RESOURCE_NAME, client_id=msi_client_id)
+            elif "MSI_OBJECT_ID" in os.environ:
+                msi_object_id = os.environ["MSI_OBJECT_ID"]
+                _logger.info('Using object_id: %s', msi_object_id)
+                credentials = MSIAuthentication(resource=VAULT_RESOURCE_NAME, object_id=msi_object_id)
+            elif "MSI_RESOURCE_ID" in os.environ:
+                msi_resource_id = os.environ["MSI_RESOURCE_ID"]
+                _logger.info('Using resource_id: %s', msi_resource_id)
+                credentials = MSIAuthentication(resource=VAULT_RESOURCE_NAME, msi_res_id=msi_resource_id)
+            else:
+                credentials = MSIAuthentication(resource=VAULT_RESOURCE_NAME)
         else:
             self._parse_sp_file()
             authority = '/'.join([AZURE_AUTHORITY_SERVER.rstrip('/'), self.tenant_id])


### PR DESCRIPTION
This change adds the option to set 3 environment variables: `MSI_CLIENT_ID`, `MSI_OBJECT_ID`, or `MSI_RESOURCE_ID`, which is needed to specify which identity if a VM uses user-assigned identities. See https://docs.microsoft.com/en-us/samples/azure-samples/resource-manager-python-manage-resources-with-msi/resource-manager-python-manage-resources-with-msi/ for more information.