### PR TITLE
Support environment variable for SP based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ docker push <image_tag>
   * `<MSI_CLIENT_ID>` - This will use a specific client_id when authenticating with MSI. This is useful if you are using user-assigned identities.
   * `<MSI_OBJECT_ID>` - This will use a specific object_id when authenticating with MSI. This is useful if you are using user-assigned identities.
   * `<MSI_CLIENT_ID>` - This will use a specific MSI resource ID when authenticating with MSI. This is useful if you are using user-assigned identities.
+  * `<USE_ENV>` - if set to `true`, it will use service principal from envirorment variable for authenticating. This flag is useful when deploying this image in ACI. However, if you want to use it in Kubernetes, please follow [guidelines](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) for securily passing environment variable.
+  * `<TENANT_ID>` - Tenant ID of the service principal
+  * `<CLIENT_ID>` - Client ID of the service principal
+  * `<CLIENT_SECRET>` - Client Secret of the service principal
 * View secrets
 ```
 kubectl get secrets

--- a/app/main.py
+++ b/app/main.py
@@ -75,6 +75,12 @@ class KeyVaultAgent(object):
 
         _logger.info('Parsing Service Principle file completed')
 
+    def _parse_sp_env(self):
+        self.tenant_id = os.environ["TENANT_ID"]
+        self.client_id = os.environ["CLIENT_ID"]
+        self.client_secret = os.environ["CLIENT_SECRET"]
+        _logger.info('Parsing Service Principle env completed')
+
     def _get_client(self):
         if os.getenv("USE_MSI", "false").lower() == "true":
             _logger.info('Using MSI')
@@ -93,7 +99,10 @@ class KeyVaultAgent(object):
             else:
                 credentials = MSIAuthentication(resource=VAULT_RESOURCE_NAME)
         else:
-            self._parse_sp_file()
+            if os.getenv("USE_ENV", "false").lower() == "true":
+                self._parse_sp_env()
+            else:
+                self._parse_sp_file()
             # azure.json file will have "msi" as the client_id and client_secret
             # if the node is running managed identity
             if self.client_id == "msi" and self.client_secret == "msi":


### PR DESCRIPTION
We are planning to use this container in ACI. We can't use MSI because ACI deployed inside vnet doesn't support it. 
Adding support to read service principal from environment variable. We can set these environment variables when creating the ACI container.

I have tested my changes in ACI containers.