### PR TITLE
Updated deprecated method call to encodestring

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -393,7 +393,7 @@ class KeyVaultAgent(object):
 
     @staticmethod
     def _cert_to_pem(cert):
-        encoded = base64.encodestring(cert)
+        encoded = base64.encodebytes(cert)
         if isinstance(encoded, bytes):
             encoded = encoded.decode("utf-8")
         encoded = '-----BEGIN CERTIFICATE-----\n' + encoded + '-----END CERTIFICATE-----\n'


### PR DESCRIPTION
Once the Dockerfile was updated to use Python 3.9, `_cert_to_pem()` begun throwing exceptions on `base64.encodestring()` as that method was removed. I replaced the method call with `base64.encodebytes()` as `encodestring()` was an alias for `encodebytes()`. 

Resolves #44 