### PR TITLE
Add option to save PFX file as well as PEM files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ docker push <image_tag>
   for example
   `mysecret:9d90276b377b4d9ea10763c153a2f015;anotherone;`
   * `<DOWNLOAD_CA_CERTIFICATES>` - By default, CA certificates are downloaded as well. Setting the environment variable to `true` or `false` controls this behavior.
+  * `<SAVE_PFX>` - If `true`, the original PFX exported from Azure Key Vault is saved alongside the PEM format key file, with a `.pfx` file extension, for any certificates to be stored in the filesystem. Default is `false`.
   * `<VAULT_BASE_URL>` - A string value that is the base url of the keyvault. It should look something like this: `https://<NAME>.vault.azure.net`.
   * `<SECRETS_TYPE>` - a string value that determines the type of secret created. For example, 'kubernetes.io/tls', 'Opaque' etc. Default is 'Opaque'.
   * If you like to create secrets of a particular kind (for example for use in DaemonSets), create an environment variable with the name of the secret that you are creating in uppercase appended by `_SECRET_TYPE`. For example, if the key name in keyvault is `mysecret` then to create a secret of type `MyCustomType`, set the environment variable `MYSECRET_SECRET_TYPE` to `MyCustomType`. This will be applicable only for that secret name, and overrides any value set for '<SECRETS_TYPE>' key. Default is 'Opaque'.

--- a/app/main.py
+++ b/app/main.py
@@ -381,7 +381,7 @@ class KeyVaultAgent(object):
 
         # Saves the PFX file together with the key file (with .pfx extension).
         # As it contains key material, we save it to the same place as keys.
-        if os.getenv('SAVE_PFX','true').lower() == "true":
+        if os.getenv('SAVE_PFX','false').lower() == "true":
             _logger.info('Dumping PFX to: %s', pfx_path)
 
             with open(pfx_path, 'wb') as pfx_file:

--- a/app/main.py
+++ b/app/main.py
@@ -368,14 +368,24 @@ class KeyVaultAgent(object):
         if (cert_filename == key_filename):
             key_path = os.path.join(self._keys_output_folder, key_filename)
             cert_path = os.path.join(self._certs_output_folder, cert_filename)
+            pfx_path = os.path.join(self._keys_output_folder, key_filename + ".pfx")
         else:
             # write to certs_keys folder when cert_filename and key_filename specified
             key_path = os.path.join(self._cert_keys_output_folder, key_filename)
             cert_path = os.path.join(self._cert_keys_output_folder, cert_filename)
+            pfx_path = os.path.join(self._cert_keys_output_folder, key_filename + ".pfx")
 
         _logger.info('Dumping key value to: %s', key_path)
         with open(key_path, 'w') as key_file:
             key_file.write(pk.decode())
+
+        # Saves the PFX file together with the key file (with .pfx extension).
+        # As it contains key material, we save it to the same place as keys.
+        if os.getenv('SAVE_PFX','true').lower() == "true":
+            _logger.info('Dumping PFX to: %s', pfx_path)
+
+            with open(pfx_path, 'wb') as pfx_file:
+                pfx_file.write(base64.b64decode(pfx))
 
         _logger.info('Dumping certs to: %s', cert_path)
         with open(cert_path, 'w') as cert_file:


### PR DESCRIPTION
This adds a new env variable `SAVE_PFX` which, if set to `true`, will save the original PFX alongside the keyfile. Default is `false`.

Closes #50.