### PR TITLE
Add timeout for client operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ docker push <image_tag>
   * `<TENANT_ID>` - Tenant ID of the service principal
   * `<CLIENT_ID>` - Client ID of the service principal
   * `<CLIENT_SECRET>` - Client Secret of the service principal
+  * `<TIMEOUT>` - Add Timeouts for all Clients default(300s) 
 * View secrets
 ```
 kubectl get secrets

--- a/app/main.py
+++ b/app/main.py
@@ -46,6 +46,7 @@ logging_core_pipeline = logging.getLogger('azure.core.pipeline.policies.http_log
 logging_core_pipeline.setLevel(logging.WARNING)
 
 AZURE_AUTHORITY_SERVER = os.getenv('AZURE_AUTHORITY_SERVER', 'https://login.microsoftonline.com/')
+TIMEOUT = int(os.getenv('TIMEOUT', '300'))
 
 class KeyVaultAgent(object):
     """
@@ -260,7 +261,7 @@ class KeyVaultAgent(object):
         self._secrets_namespace = os.getenv('SECRETS_NAMESPACE','default')
 
         credential = self._get_credential()
-        secret_client = SecretClient(vault_url=vault_base_url, credential=credential)
+        secret_client = SecretClient(vault_url=vault_base_url, credential=credential, timeout=TIMEOUT)
         _logger.info('Using vault: %s', vault_base_url)
 
         # Retrieving all secrets from Key Vault if specified by user
@@ -310,8 +311,8 @@ class KeyVaultAgent(object):
                 os.makedirs(folder)
 
         credential = self._get_credential()
-        secret_client = SecretClient(vault_url=vault_base_url, credential=credential)
-        certificate_client = CertificateClient(vault_url=vault_base_url, credential=credential)
+        secret_client = SecretClient(vault_url=vault_base_url, credential=credential, timeout=TIMEOUT)
+        certificate_client = CertificateClient(vault_url=vault_base_url, credential=credential, timeout=TIMEOUT)
         _logger.info('Using vault: %s', vault_base_url)
 
         # Retrieving all secrets from Key Vault if specified by user


### PR DESCRIPTION
As per [azure python sdk guidelines](https://azure.github.io/azure-sdk/python_design.html) all libraries `s  ServiceClients support some common parameters like timeout.

```
# Change default number of retries to 18 and overall timeout to 2s.
client = ExampleClient('https://contoso.com/xmpl',
                       DefaultAzureCredential(),
                       max_retries=18,
                       timeout=2)
```
Adding timeout defaulting to 300seconds for all clients used in acskeyvaultagent